### PR TITLE
リプライ時のポスト作成 modal での残り文字数計算を前後の空白を除去した計算に #46 リンクなどのrich text の対象範囲がずれる対応 #118

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
         "@types/react-dom": "18.2.7",
         "@use-gesture/react": "^10.3.0",
         "autoprefixer": "10.4.16",
+        "browser-image-compression": "^2.0.2",
+        "compressorjs": "^1.2.1",
         "eslint-config-next": "13.5.2",
         "framer-motion": "^10.16.4",
         "jotai": "^2.4.2",
@@ -46,6 +48,8 @@
       "devDependencies": {
         "@types/react-image-gallery": "^1.2.1",
         "@types/react-infinite-scroller": "^1.2.3",
+        "@typescript-eslint/eslint-plugin": "^6.7.4",
+        "@typescript-eslint/parser": "^6.7.4",
         "eslint": "8.50.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.28.1",
@@ -2668,6 +2672,12 @@
       "resolved": "https://registry.npmjs.org/@types/flat/-/flat-5.0.3.tgz",
       "integrity": "sha512-uG/4x6EXYbq4VDsBJLNDHQAQmtRPg3x4tAXcBspxlnEknz8NiJxnHoxSiJKGNExiS00q4mJNvuEBgVA3jsDIdQ=="
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
+      "dev": true
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -2769,15 +2779,56 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.2.tgz",
-      "integrity": "sha512-KA3E4ox0ws+SPyxQf9iSI25R6b4Ne78ORhNHeVKrPQnoYsb9UhieoiRoJgrzgEeKGOXhcY1i8YtOeCHHTDa6Fw==",
+    "node_modules/@types/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.5.tgz",
+      "integrity": "sha512-JhtAwTRhOUcP96D0Y6KYnwig/MRQbOoLGXTON2+LlyB/N35SP9j1boai2zzwXb7ypKELXMx3DVk9UTaEq1vHEw==",
+      "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.7.2",
-        "@typescript-eslint/types": "6.7.2",
-        "@typescript-eslint/typescript-estree": "6.7.2",
-        "@typescript-eslint/visitor-keys": "6.7.2",
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.7.5",
+        "@typescript-eslint/type-utils": "6.7.5",
+        "@typescript-eslint/utils": "6.7.5",
+        "@typescript-eslint/visitor-keys": "6.7.5",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.5.tgz",
+      "integrity": "sha512-bIZVSGx2UME/lmhLcjdVc7ePBwn7CLqKarUBL4me1C5feOd663liTGjMBGVcGr+BhnSLeP4SgwdvNnnkbIdkCw==",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.7.5",
+        "@typescript-eslint/types": "6.7.5",
+        "@typescript-eslint/typescript-estree": "6.7.5",
+        "@typescript-eslint/visitor-keys": "6.7.5",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2797,12 +2848,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.2.tgz",
-      "integrity": "sha512-bgi6plgyZjEqapr7u2mhxGR6E8WCzKNUFWNh6fkpVe9+yzRZeYtDTbsIBzKbcxI+r1qVWt6VIoMSNZ4r2A+6Yw==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.5.tgz",
+      "integrity": "sha512-GAlk3eQIwWOJeb9F7MKQ6Jbah/vx1zETSDw8likab/eFcqkjSD7BI75SDAeC5N2L0MmConMoPvTsmkrg71+B1A==",
       "dependencies": {
-        "@typescript-eslint/types": "6.7.2",
-        "@typescript-eslint/visitor-keys": "6.7.2"
+        "@typescript-eslint/types": "6.7.5",
+        "@typescript-eslint/visitor-keys": "6.7.5"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2812,10 +2863,37 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.5.tgz",
+      "integrity": "sha512-Gs0qos5wqxnQrvpYv+pf3XfcRXW6jiAn9zE/K+DlmYf6FcpxeNYN0AIETaPR7rHO4K2UY+D0CIbDP9Ut0U4m1g==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.7.5",
+        "@typescript-eslint/utils": "6.7.5",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.2.tgz",
-      "integrity": "sha512-flJYwMYgnUNDAN9/GAI3l8+wTmvTYdv64fcH8aoJK76Y+1FCZ08RtI5zDerM/FYT5DMkAc+19E4aLmd5KqdFyg==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.5.tgz",
+      "integrity": "sha512-WboQBlOXtdj1tDFPyIthpKrUb+kZf2VroLZhxKa/VlwLlLyqv/PwUNgL30BlTVZV1Wu4Asu2mMYPqarSO4L5ZQ==",
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -2825,12 +2903,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.2.tgz",
-      "integrity": "sha512-kiJKVMLkoSciGyFU0TOY0fRxnp9qq1AzVOHNeN1+B9erKFCJ4Z8WdjAkKQPP+b1pWStGFqezMLltxO+308dJTQ==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.5.tgz",
+      "integrity": "sha512-NhJiJ4KdtwBIxrKl0BqG1Ur+uw7FiOnOThcYx9DpOGJ/Abc9z2xNzLeirCG02Ig3vkvrc2qFLmYSSsaITbKjlg==",
       "dependencies": {
-        "@typescript-eslint/types": "6.7.2",
-        "@typescript-eslint/visitor-keys": "6.7.2",
+        "@typescript-eslint/types": "6.7.5",
+        "@typescript-eslint/visitor-keys": "6.7.5",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2850,12 +2928,37 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.2.tgz",
-      "integrity": "sha512-uVw9VIMFBUTz8rIeaUT3fFe8xIUx8r4ywAdlQv1ifH+6acn/XF8Y6rwJ7XNmkNMDrTW+7+vxFFPIF40nJCVsMQ==",
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.5.tgz",
+      "integrity": "sha512-pfRRrH20thJbzPPlPc4j0UNGvH1PjPlhlCMq4Yx7EGjV7lvEeGX0U6MJYe8+SyFutWgSHsdbJ3BXzZccYggezA==",
+      "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.7.2",
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.7.5",
+        "@typescript-eslint/types": "6.7.5",
+        "@typescript-eslint/typescript-estree": "6.7.5",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.5.tgz",
+      "integrity": "sha512-3MaWdDZtLlsexZzDSdQWsFQ9l9nL8B80Z4fImSpyllFC/KLqWQRdEcB+gGGO+N3Q2uL40EsG66wZLsohPxNXvg==",
+      "dependencies": {
+        "@typescript-eslint/types": "6.7.5",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -3201,6 +3304,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/blueimp-canvas-to-blob": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.29.0.tgz",
+      "integrity": "sha512-0pcSSGxC0QxT+yVkivxIqW0Y4VlO2XSDPofBAqoJ1qJxgH9eiUDLv50Rixij2cDuEfx4M6DpD9UGZpRhT5Q8qg=="
+    },
     "node_modules/bplist-parser": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
@@ -3231,6 +3339,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -3450,6 +3566,15 @@
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/compressorjs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/compressorjs/-/compressorjs-1.2.1.tgz",
+      "integrity": "sha512-+geIjeRnPhQ+LLvvA7wxBQE5ddeLU7pJ3FsKFWirDw6veY3s9iLxAQEw7lXGHnhCJvBujEQWuNnGzZcvCvdkLQ==",
+      "dependencies": {
+        "blueimp-canvas-to-blob": "^3.29.0",
+        "is-blob": "^2.1.0"
       }
     },
     "node_modules/compute-scroll-into-view": {
@@ -4854,6 +4979,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-blob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-boolean-object": {
@@ -7301,6 +7437,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "node_modules/watchpack": {
       "version": "2.4.0",

--- a/src/app/components/PostModal/PostModal.tsx
+++ b/src/app/components/PostModal/PostModal.tsx
@@ -148,6 +148,10 @@ export const PostModal: React.FC<Props> = (props: Props) => {
         return () => matchMedia.removeEventListener("change", modeMe)
     }, [])
 
+    const trimedContentText = (): string => {
+        return contentText.trim()
+    }
+
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
             handlePostClick()
@@ -173,7 +177,7 @@ export const PostModal: React.FC<Props> = (props: Props) => {
     const handlePostClick = async () => {
         console.log(agent)
         if (!agent) return
-        if (contentText.trim() === "") return
+        if (trimedContentText() === "") return
         setLoading(true)
         try {
             const blobRefs: BlobRef[] = []
@@ -191,7 +195,7 @@ export const PostModal: React.FC<Props> = (props: Props) => {
                 blobRefs.push(blobRef)
             }
 
-            const rt = new RichText({ text: contentText })
+            const rt = new RichText({ text: trimedContentText() })
             await rt.detectFacets(agent)
 
             const postObj: Partial<AppBskyFeedPost.Record> &
@@ -487,8 +491,8 @@ export const PostModal: React.FC<Props> = (props: Props) => {
                         }}
                         isDisabled={
                             loading ||
-                            contentText.trim().length === 0 ||
-                            contentText.trim().length > 300
+                            trimedContentText().length === 0 ||
+                            trimedContentText().length > 300
                         }
                         isLoading={loading}
                     >
@@ -904,12 +908,12 @@ export const PostModal: React.FC<Props> = (props: Props) => {
                                 className={footerCharacterCountText()}
                                 style={{
                                     color:
-                                        contentText.trim().length >= 300
+                                        trimedContentText().length >= 300
                                             ? "red"
                                             : "white",
                                 }}
                             >
-                                {300 - contentText.trim().length}
+                                {300 - trimedContentText().length}
                             </div>
                             <div
                                 style={{
@@ -919,11 +923,11 @@ export const PostModal: React.FC<Props> = (props: Props) => {
                                 }}
                             >
                                 <CircularProgressbar
-                                    value={contentText.trim().length}
+                                    value={trimedContentText().length}
                                     maxValue={300}
                                     styles={buildStyles({
                                         pathColor:
-                                            contentText.trim().length >= 300
+                                            trimedContentText().length >= 300
                                                 ? "red"
                                                 : "deepskyblue",
                                     })}

--- a/src/app/components/PostModal/PostModal.tsx
+++ b/src/app/components/PostModal/PostModal.tsx
@@ -909,7 +909,7 @@ export const PostModal: React.FC<Props> = (props: Props) => {
                                             : "white",
                                 }}
                             >
-                                {300 - contentText.length}
+                                {300 - contentText.trim().length}
                             </div>
                             <div
                                 style={{

--- a/src/app/post/page.tsx
+++ b/src/app/post/page.tsx
@@ -165,6 +165,10 @@ export default function Root() {
         }
     }, [appearanceColor])
 
+    const trimedContentText = (): string => {
+        return contentText.trim()
+    }
+
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
             handlePostClick()
@@ -193,7 +197,7 @@ export default function Root() {
     const handlePostClick = async () => {
         console.log(agent)
         if (!agent) return
-        if (contentText.trim() === "") return
+        if (trimedContentText() === "") return
         setLoading(true)
         try {
             const blobRefs: BlobRef[] = []
@@ -214,7 +218,7 @@ export default function Root() {
                 blobRefs.push(blobRef)
             }
 
-            const rt = new RichText({ text: contentText })
+            const rt = new RichText({ text: trimedContentText() })
             await rt.detectFacets(agent)
             const postObj: Partial<AppBskyFeedPost.Record> &
                 Omit<AppBskyFeedPost.Record, "createdAt"> = {
@@ -499,8 +503,8 @@ export default function Root() {
                         onPress={handlePostClick}
                         isDisabled={
                             loading ||
-                            contentText.trim().length === 0 ||
-                            contentText.trim().length > 300 // ||
+                            trimedContentText().length === 0 ||
+                            trimedContentText().length > 300 // ||
                             // isImageMaxLimited
                         }
                         isLoading={loading}
@@ -889,12 +893,12 @@ export default function Root() {
                                 className={footerCharacterCountText()}
                                 style={{
                                     color:
-                                        contentText.length >= 300
+                                        trimedContentText().length >= 300
                                             ? "red"
                                             : "white",
                                 }}
                             >
-                                {300 - contentText.trim().length}
+                                {300 - trimedContentText().length}
                             </div>
                             <div
                                 style={{
@@ -904,11 +908,11 @@ export default function Root() {
                                 }}
                             >
                                 <CircularProgressbar
-                                    value={contentText.trim().length}
+                                    value={trimedContentText().length}
                                     maxValue={300}
                                     styles={buildStyles({
                                         pathColor:
-                                            contentText.trim().length >= 300
+                                            trimedContentText().length >= 300
                                                 ? "red"
                                                 : "deepskyblue",
                                     })}


### PR DESCRIPTION
## リプライ時のポスト作成 modal での残り文字数計算を前後の空白を除去した計算に

- `src/app/components/PostModal/PostModal.tsx` での、残り文字数計算で、対象文字列を `trim()` していなかった 

## 本文の先頭に空白などがあると、リンクなどのrich text の対象範囲がずれる対応 #118

- `src/app/components/PostModal/PostModal.tsx`
- `src/app/post/page.tsx`

それぞれで、`trim()` した結果の文字列が必要な場合に、都度`trim()`をするのではなく、`trimedContentText()` メソッドを追加し、取得するように修正。
